### PR TITLE
Improve display timing with muxer on a thread and better timing logic

### DIFF
--- a/jumpstreet/display.py
+++ b/jumpstreet/display.py
@@ -1,8 +1,7 @@
 #!/usr/bin/python3
 # -*- coding: utf-8 -*-
 
-import logging
-from jumpstreet.utils import BaseClass
+from jumpstreet.utils import BaseClass, TimeMonitor
 from PyQt5.QtCore import Qt, QThread
 from PyQt5.QtGui import QImage, QPixmap, QPalette, QPainter
 from PyQt5.QtPrintSupport import QPrintDialog, QPrinter
@@ -66,9 +65,9 @@ class StreamThrough(Display):
 class QImageViewer(QMainWindow):
     def __init__(self, width=800, height=800):
         super().__init__()
-
         self.printer = QPrinter()
         self.scaleFactor = 0.0
+        self.time_monitor = TimeMonitor()
 
         self.imageLabel = QLabel()
         self.imageLabel.setBackgroundRole(QPalette.Base)
@@ -90,7 +89,6 @@ class QImageViewer(QMainWindow):
 
     def open(self):
         options = QFileDialog.Options()
-        # fileName = QFileDialog.getOpenFileName(self, "Open File", QDir.currentPath())
         fileName, _ = QFileDialog.getOpenFileName(self, 'QFileDialog.getOpenFileName()', '',
                                                   'Images (*.png *.jpeg *.jpg *.bmp *.gif)', options=options)
         if fileName:
@@ -114,6 +112,7 @@ class QImageViewer(QMainWindow):
         self.printAct.setEnabled(True)
         self.fitToWindowAct.setEnabled(True)
         self.updateActions()
+        self.time_monitor.trigger()
 
         if not self.fitToWindowAct.isChecked():
             self.imageLabel.adjustSize()

--- a/jumpstreet/frontend/simple.py
+++ b/jumpstreet/frontend/simple.py
@@ -18,7 +18,7 @@ import jumpstreet
 class MainLoop(QObject):
     update = pyqtSignal(object)
 
-    def __init__(self, context, HOST, PORT_TRACKS, PORT_IMAGES, dt_delay=0.10):
+    def __init__(self, context, HOST, PORT_TRACKS, PORT_IMAGES, dt_delay=0.1):
         super().__init__()
         self.quit_flag = False
 
@@ -55,7 +55,9 @@ class MainLoop(QObject):
         self.track_buffer = jumpstreet.buffer.BasicDataBuffer(identifier=0, max_size=30)
         self.muxer = jumpstreet.muxer.VideoTrackMuxer(
             self.video_buffer, self.track_buffer, identifier=0)
+        self.t_first_image = None
         self.t_last_image = None
+        self.t_first_emit = None
         self.t_last_emit = None
         self.dt_delay = dt_delay
 
@@ -65,10 +67,11 @@ class MainLoop(QObject):
         self.video_buffer.init()
         self.track_buffer.init()
         self.muxer.init()
+        # -- put the muxer process on a thread that executes at a certain rate
+        self.muxer.start_continuous_process_thread(execute_rate=100, t_max_delta=0.1)
         try:
             while True:
-                socks = dict(self.poller.poll(timeout=10))  # timeout in ms
-                # TODO: have a REALLY short limit on the poller so we don't delay emitting frames
+                socks = dict(self.poller.poll(timeout=1))  # timeout in ms
 
                 # -- add video data to buffer
                 if self.frontend_images in socks:
@@ -88,11 +91,7 @@ class MainLoop(QObject):
                     track_data_container = get_data_container_from_line(data.decode(), identifier_override=0)
                     self.track_buffer.push(track_data_container)
 
-                # -- run the muxer and load an image when we're ready
-                # TODO: put the processor on a separate thread???
-                self.muxer.process()
-
-                # -- emit an image steadily, subject to a delay factor
+                # -- emit an image, subject to a delay factor
                 emit = False
                 t_now = time.time()  # should we redo time.time later on?
                 if not self.muxer.empty():
@@ -100,16 +99,27 @@ class MainLoop(QObject):
                     if self.t_last_emit is None:
                         self.t_last_emit = t_now  # say now is the last emit time
                     if self.t_last_image is None:
-                        if (t_now - self.t_last_emit) > self.dt_delay:
+                        # first time, put it on a delay
+                        self.t_first_image = t_next_image
+                        if (t_now - self.t_last_emit) >= self.dt_delay-1e-6:
                             emit = True
                     else:
-                        if (t_now - self.t_last_emit) > (t_next_image - self.t_last_image + self.dt_delay):
+                        # every other time, match the time difference and maintain the original delay
+                        # if we instead tried to match the rate between pairs of images, we could end
+                        # up with a gradually increasing global delay factor that would be very bad!
+                        dt_from_first_image = t_next_image - self.t_first_image
+                        dt_from_first_emit = t_now - self.t_first_emit
+                        if dt_from_first_emit >= (dt_from_first_image + self.dt_delay-1e-6):
                             emit = True
                 if emit:
                     image_out = self.muxer.pop(0)  # 0 is the identifier for a single camera
+                    t_now_again = time.time()
+                    if self.t_first_emit is None:
+                        self.t_first_emit = t_now_again
+                    self.dt_last = t_now_again - self.t_last_emit  # this should be about 
+                    self.t_last_emit = t_now_again
+                    self.t_last_image = t_next_image
                     self.update.emit([image_out.data])
-                    self.t_last_emit = t_now
-                    self.t_last_image = t_now
 
         except Exception as e:
             logging.warning(e, exc_info=True)

--- a/jumpstreet/object_tracking.py
+++ b/jumpstreet/object_tracking.py
@@ -2,10 +2,9 @@
 
 import argparse
 import logging
-from time import sleep
 
 import zmq
-from jumpstreet.utils import BaseClass, init_some_end
+from jumpstreet.utils import BaseClass, init_some_end, TimeMonitor
 
 from avstack.modules.perception.detections import get_data_container_from_line
 from avstack.modules.tracking.tracker2d import SortTracker2D

--- a/jumpstreet/utils.py
+++ b/jumpstreet/utils.py
@@ -1,5 +1,7 @@
 import numpy as np
 import zmq
+import time
+from collections import deque
 
 
 class BaseClass:
@@ -38,6 +40,26 @@ class BaseClass:
         except AttributeError as e:
             name = self.name
         print(f"::{name}-{self.identifier}::{msg}", end=end, flush=True)
+
+
+class TimeMonitor(BaseClass):
+    def __init__(self, maxlen=10) -> None:
+        super().__init__('time-monitor', 0, verbose=True)
+        self.dt_history = deque([], maxlen=maxlen)
+        self.last_t = None
+
+    def trigger(self):
+        if self.last_t is None:
+            self.last_t = time.time()
+        else:
+            new_t = time.time()
+            self.dt_history.append(new_t - self.last_t)
+            if len(self.dt_history) > 3:
+                self.last_t = new_t
+                dt = np.mean(self.dt_history)
+                fps = 1./dt
+                std = np.std([1./dt for dt in self.dt_history])
+                self.print(f'FPS: {fps:4.2f},   FPS std: {1./std:2.3f}', end="\r")
 
 
 def init_some_end(


### PR DESCRIPTION
@natezelter1 I improved some of the timing issues with the display with:
- Putting the muxer on its own thread that continuously runs
- Emitting images to the display based on a global time difference rather than a frame-to-frame time difference